### PR TITLE
Refactored pom, added junit dependency 4.13.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <org.testng>7.9.0</org.testng>
-        <junit>5.10.2</junit>
+        <junit-jupiter-api>5.10.2</junit-jupiter-api>
+        <junit>4.13.2</junit>
         <selenium>4.18.1</selenium>
     </properties>
 
@@ -23,13 +24,20 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <scope>test</scope>
             <version>${org.testng}</version>
+            <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-api}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <version>${junit}</version>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
testFibonachi was failing due to being unable to import org.junit.Assert and import org.junit.Test  
Refactored pom, added  new junit dependency 4.13.2 